### PR TITLE
Use views to split `k` and `xyu`

### DIFF
--- a/src/GridapPDENLPModel.jl
+++ b/src/GridapPDENLPModel.jl
@@ -146,7 +146,8 @@ function obj(nlp::GridapPDENLPModel, x::AbstractVector)
   @lencheck nlp.meta.nvar x
   increment!(nlp, :neval_obj)
 
-  κ, xyu = x[1:(nlp.pdemeta.nparam)], x[(nlp.pdemeta.nparam + 1):(nlp.meta.nvar)]
+  κ = @view x[1:(nlp.pdemeta.nparam)]
+  xyu = @view x[(nlp.pdemeta.nparam + 1):(nlp.meta.nvar)]
   yu = FEFunction(nlp.pdemeta.Y, xyu)
   int = _obj_integral(nlp.pdemeta.tnrj, κ, yu)
 
@@ -157,7 +158,8 @@ function grad!(nlp::GridapPDENLPModel, x::AbstractVector, g::AbstractVector)
   @lencheck nlp.meta.nvar x g
   increment!(nlp, :neval_grad)
 
-  κ, xyu = x[1:(nlp.pdemeta.nparam)], x[(nlp.pdemeta.nparam + 1):(nlp.meta.nvar)]
+  κ = @view x[1:(nlp.pdemeta.nparam)]
+  xyu = @view x[(nlp.pdemeta.nparam + 1):(nlp.meta.nvar)]
   yu = FEFunction(nlp.pdemeta.Y, xyu)
 
   return _compute_gradient!(g, nlp.pdemeta.tnrj, κ, yu, nlp.pdemeta.Y, nlp.pdemeta.X)
@@ -173,7 +175,8 @@ function hess_coord!(
   @lencheck nlp.meta.nnzh vals
   increment!(nlp, :neval_hess)
 
-  κ, xyu = x[1:(nlp.pdemeta.nparam)], x[(nlp.pdemeta.nparam + 1):(nlp.meta.nvar)]
+  κ = @view x[1:(nlp.pdemeta.nparam)]
+  xyu = @view x[(nlp.pdemeta.nparam + 1):(nlp.meta.nvar)]
   yu = FEFunction(nlp.pdemeta.Y, xyu)
 
   nnz_hess_k = get_nnz_hess_k(nlp.pdemeta.tnrj, nlp.meta.nvar, nlp.pdemeta.nparam)
@@ -252,7 +255,8 @@ function hess_coord!(
   nini = nlp.pdemeta.nnzh_obj
 
   p, n = nlp.pdemeta.nparam, nlp.meta.nvar
-  κ, xyu = x[1:p], x[(p + 1):n]
+  κ = @view x[1:p]
+  xyu = @view x[(p + 1):n]
 
   if p > 0
     nnz_hess_k = Int(p * (p + 1) / 2) + (n - p) * p

--- a/src/additional_obj_terms.jl
+++ b/src/additional_obj_terms.jl
@@ -301,7 +301,8 @@ function _compute_hess_k_vals!(
     agrad = @closure (g, k) -> _compute_gradient_k!(g, nlp.pdemeta.tnrj, k, yu)
   else
     function _obj(x)
-      κ, xyu = x[1:(nlp.pdemeta.nparam)], x[(nlp.pdemeta.nparam + 1):(nlp.meta.nvar)]
+      κ = @view x[1:(nlp.pdemeta.nparam)]
+      xyu = @view x[(nlp.pdemeta.nparam + 1):(nlp.meta.nvar)]
       yu = FEFunction(nlp.pdemeta.Y, xyu)
       int = _obj_integral(nlp.pdemeta.tnrj, κ, yu)
       return sum(int)

--- a/src/hessian_struct_nnzh_functions.jl
+++ b/src/hessian_struct_nnzh_functions.jl
@@ -19,8 +19,8 @@ end
 
 function _compute_hess_structure_obj(tnrj::AbstractEnergyTerm, Y, X, x0, nparam)
   nini = 0
-  nvar = length(x0)
-  κ, xyu = x0[1:nparam], x0[(nparam + 1):nvar]
+  κ = @view x0[1:nparam]
+  xyu = @view x0[(nparam + 1):end]
   xh = FEFunction(Y, xyu)
 
   luh = _obj_integral(tnrj, κ, xh)
@@ -79,11 +79,10 @@ function _compute_hess_structure(
   nparam,
 ) where {T}
   λ = zeros(Gridap.FESpaces.num_free_dofs(Ypde))
-  λf = FEFunction(Xpde, λ) # or Ypde
-  nvar = length(x0)
-  κ, xyu = x0[1:nparam], x0[(nparam + 1):nvar]
+  λf = FEFunction(Xpde, λ)
+  κ = @view x0[1:nparam]
+  xyu = @view x0[(nparam + 1):end]
   xh = FEFunction(Y, xyu)
-  nvar = length(xyu)
 
   function split_res(x, λ)
     if typeof(Ycon) <: VoidFESpace

--- a/src/jacobian_functions.jl
+++ b/src/jacobian_functions.jl
@@ -61,8 +61,8 @@ function _from_terms_to_residual!(
   Ycon::FESpace,
   res::AbstractVector,
 )
-  κ, xyu = x[1:(nparam)], x[(nparam + 1):end]
-  yu = FEFunction(Y, xyu)
+  κ = @view x[1:(nparam)]
+  xyu = @view x[(nparam + 1):end]
   y, u = _split_FEFunction(xyu, Ypde, Ycon)
 
   # Gridap.FESpaces.residual(op, FEFunction(Y, x))
@@ -101,8 +101,7 @@ function _jacobian_struct(
   nyu = num_free_dofs(Y)
   nparam = nvar - nyu
   yh, uh = _split_FEFunction(x, Ypde, Ycon)
-  κ, xyu = x[1:nparam], x[(nparam + 1):nvar]
-  yu = FEFunction(Y, xyu)
+  κ = @view x[1:nparam]
 
   v = Gridap.FESpaces.get_cell_shapefuns(Xpde)
 
@@ -167,7 +166,8 @@ function _jac_coord!(
 ) where {T}
   nnz_jac_k = nparam > 0 ? ncon * nparam : 0
   if nparam > 0
-    κ, xyu = x[1:(nparam)], x[(nparam + 1):end]
+    κ = @view x[1:(nparam)]
+    xyu = @view x[(nparam + 1):end]
     ck = @closure (c, k) -> _from_terms_to_residual!(op, vcat(k, xyu), nparam, Y, Ypde, Ycon, c)
     ForwardDiff.jacobian!(Jk, ck, c, κ)
     vals[1:nnz_jac_k] .= Jk[:]
@@ -189,7 +189,8 @@ function _from_terms_to_jacobian_vals!(
   nvar = length(x)
   nyu = num_free_dofs(Y)
   nparam = nvar - nyu
-  κ, xyu = x[1:nparam], x[(nparam + 1):nvar]
+  κ = @view x[1:nparam]
+  xyu = @view x[(nparam + 1):end]
   yh, uh = _split_FEFunction(xyu, Ypde, Ycon)
 
   v = Gridap.FESpaces.get_cell_shapefuns(Xpde)


### PR DESCRIPTION
# Benchmark Report for *PDENLPModels*

## Job Properties
* Time of benchmarks:
    - Target: 2 Aug 2021 - 13:32
    - Baseline: 2 Aug 2021 - 13:38
* Package commits:
    - Target: e59266
    - Baseline: f37505

## Results
A ratio greater than `1.0` denotes a possible regression (marked with :x:), while a ratio less
than `1.0` denotes a possible improvement (marked with :white_check_mark:). Only significant results - results
that indicate possible regressions or improvements - are shown below (thus, an empty table means that all
benchmark results remained invariant between builds).

| ID                                     | time ratio                   | memory ratio                 |
|----------------------------------------|------------------------------|------------------------------|
| `["grad", "apinene"]`                  | 0.94 (5%) :white_check_mark: |                1.01 (1%) :x: |
| `["grad", "burger1d_param"]`           |                   0.98 (5%)  |                1.03 (1%) :x: |
| `["grad", "gasoil"]`                   |                   0.99 (5%)  |                1.01 (1%) :x: |
| `["hess_coord", "apinene"]`            |                1.07 (5%) :x: |                   1.00 (1%)  |
| `["hess_coord", "burger1d_param"]`     |                1.12 (5%) :x: |                1.02 (1%) :x: |
| `["hess_lag_coord", "apinene"]`        | 0.21 (5%) :white_check_mark: | 0.86 (1%) :white_check_mark: |
| `["hess_lag_coord", "burger1d_param"]` | 0.05 (5%) :white_check_mark: | 0.35 (1%) :white_check_mark: |
| `["hess_lag_coord", "gasoil"]`         | 0.01 (5%) :white_check_mark: | 0.11 (1%) :white_check_mark: |
| `["hess_structure", "apinene"]`        |            60652.40 (5%) :x: |                   1.00 (1%)  |
| `["hess_structure", "burger1d_param"]` |            67142.86 (5%) :x: |                   1.00 (1%)  |
| `["hess_structure", "gasoil"]`         |            61326.53 (5%) :x: |                   1.00 (1%)  |
| `["jac_coord", "apinene"]`             | 0.01 (5%) :white_check_mark: | 0.10 (1%) :white_check_mark: |
| `["jac_coord", "burger1d_param"]`      | 0.00 (5%) :white_check_mark: | 0.05 (1%) :white_check_mark: |
| `["jac_coord", "gasoil"]`              | 0.00 (5%) :white_check_mark: | 0.02 (1%) :white_check_mark: |
| `["jac_structure", "apinene"]`         |            60348.36 (5%) :x: |                   1.00 (1%)  |
| `["jac_structure", "burger1d_param"]`  |            63831.97 (5%) :x: |                   1.00 (1%)  |
| `["jac_structure", "gasoil"]`          |            64241.80 (5%) :x: |                   1.00 (1%)  |
| `["obj", "apinene"]`                   |                   1.03 (5%)  |                1.04 (1%) :x: |
| `["obj", "burger1d_param"]`            |                1.05 (5%) :x: |                1.11 (1%) :x: |
| `["obj", "gasoil"]`                    |                   1.03 (5%)  |                1.04 (1%) :x: |
```

There is a large time differenc, because of the garbage collector, but there is a significant improvement in the allocations.